### PR TITLE
Fix Mailto: link

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
                             <i class="fa fa-phone fa-3x sr-contact"></i><p class="network-name">+91 7200210789</p>
                         </li>
                         <li class="r">
-                            <i class="fa fa-envelope-o fa-3x sr-contact"></i><p class="network-name1"><a href="mailto:your-email@your-domain.com">admin.ceglug@gmail.com</a></p>
+                            <i class="fa fa-envelope-o fa-3x sr-contact"></i><p class="network-name1"><a href="mailto:admin.ceglug@gmail.com">admin.ceglug@gmail.com</a></p>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Currently when you click the mail hyperlink in the website it will take you to "your-email@your-domain.com" mail.  I just fixed the small bug. 